### PR TITLE
Aggiungi guida ESPHome per luminosità automatica display JC2432W328

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,93 @@
 # home_assistant
+
+## ESPHome (JC2432W328): luminosità display automatica con sensore luce
+
+Per aggiungere la gestione automatica della retroilluminazione (backlight) in base al sensore luce già presente sul JC2432W328, inserisci questi blocchi nel tuo YAML ESPHome.
+
+### 1) Substitutions (soglie e limiti)
+
+```yaml
+substitutions:
+  # ...già esistenti...
+  ldr_update_interval: "5s"       # frequenza aggiornamento luminosità
+  ldr_dark_voltage: "2.70"        # più alto = più buio (tarare sul tuo pannello)
+  ldr_bright_voltage: "0.40"      # più basso = più luce (tarare sul tuo pannello)
+  backlight_min: "0.20"           # luminosità minima (0.00-1.00)
+  backlight_max: "1.00"           # luminosità massima (0.00-1.00)
+```
+
+### 2) Sensore ADC per LDR (pin tipico CYD: GPIO34)
+
+```yaml
+sensor:
+  # --- Sensore luce onboard (LDR) ---
+  - platform: adc
+    pin: GPIO34
+    id: ambient_light_adc
+    name: "${friendly_name} Ambient Light ADC"
+    attenuation: auto
+    update_interval: ${ldr_update_interval}
+    filters:
+      - median:
+          window_size: 7
+          send_every: 1
+          send_first_at: 1
+      - exponential_moving_average:
+          alpha: 0.2
+          send_every: 1
+    on_value:
+      then:
+        - lambda: |-
+            // Mappa tensione LDR -> luminosità backlight.
+            // Su CYD comune: più luce => tensione più bassa.
+            const float v_dark = ${ldr_dark_voltage};
+            const float v_bright = ${ldr_bright_voltage};
+
+            // Normalizzazione invertita: 0=buio, 1=luce
+            float norm = (v_dark - x) / (v_dark - v_bright);
+            if (norm < 0.0f) norm = 0.0f;
+            if (norm > 1.0f) norm = 1.0f;
+
+            // Limiti luminosità reali (0..1)
+            const float min_b = ${backlight_min};
+            const float max_b = ${backlight_max};
+            float target = min_b + (max_b - min_b) * norm;
+
+            // Evita aggiornamenti troppo frequenti (flicker)
+            static float last = -1.0f;
+            if (last < 0.0f || fabsf(target - last) >= 0.03f) {
+              auto call = id(backlight).turn_on();
+              call.set_brightness(target);
+              call.set_transition_length(800);
+              call.perform();
+              last = target;
+            }
+```
+
+> Se nel tuo modulo il comportamento fosse invertito (più luce = tensione più alta), usa:
+> `float norm = (x - v_dark) / (v_bright - v_dark);`
+
+### 3) Mantieni la luce backlight esistente
+
+Il tuo blocco attuale va bene; assicurati solo che `id: backlight` resti invariato:
+
+```yaml
+output:
+  - platform: ledc
+    pin: GPIO27
+    id: backlight_pwm
+
+light:
+  - platform: monochromatic
+    output: backlight_pwm
+    name: Display Backlight
+    id: backlight
+    restore_mode: ALWAYS_ON
+    default_transition_length: 0.5s
+```
+
+### Note pratiche di taratura
+
+- Se di notte è ancora troppo forte, aumenta `ldr_dark_voltage` o abbassa `backlight_min`.
+- Se di giorno è troppo bassa, diminuisci `ldr_bright_voltage`.
+- Per debug rapido, osserva il valore del sensore `Ambient Light ADC` in Home Assistant e regola le due soglie.


### PR DESCRIPTION
### Motivation
- Fornire una guida pronta all’uso per abilitare la regolazione automatica della retroilluminazione del display JC2432W328 usando il sensore di luce già presente.
- Rendere facilmente riutilizzabile il codice ESPHome con soglie e parametri configurabili tramite `substitutions`.

### Description
- Aggiunto un nuovo blocco nella `README.md` con snippet YAML per le `substitutions` (`ldr_update_interval`, `ldr_dark_voltage`, `ldr_bright_voltage`, `backlight_min`, `backlight_max`).
- Inserito esempio di `sensor` ADC su `GPIO34` (`id: ambient_light_adc`) con filtri (`median`, `exponential_moving_average`) e logica `on_value` che mappa la tensione LDR in luminosità del `light` `id: backlight` usando una lambda C++.
- Documentata la conservazione del blocco `output`/`light` esistente (es. `backlight_pwm` e `backlight`) e fornita una nota per gestire eventuale inversione della curva sensore.
- Aggiunte indicazioni pratiche per la taratura delle soglie e per il debug tramite il sensore `Ambient Light ADC` in Home Assistant.

### Testing
- Verificato il `README.md` aggiornato e ispezionato il diff contenente la nuova sezione di configurazione, esito positivo.
- Eseguita ricerca dei pattern chiave (`backlight_min`, `const float min_b`) nel file e riscontro corretto dei valori inseriti.
- Controllato lo stato del repository locale e le modifiche sono state registrate senza errori come modifica documentale.
- Nessun test di compilazione o runtime eseguito perché la modifica è esclusivamente documentale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db97453cc4832191300e38a13bdd6c)